### PR TITLE
Refactor: check build scripts

### DIFF
--- a/.release-it.ts
+++ b/.release-it.ts
@@ -17,8 +17,17 @@ export default {
         publish: false,
     },
     hooks: {
-        "before:init": ["bun run test:run", "bun run typecheck", "bun run check", "bun run prepack", "bun run publint"],
-        "after:bump": ["bun run git-cliff --output CHANGELOG.md --tag ${version}", "bun run check:fix"],
+        "before:init": [
+            "bun run test:run",
+            "bun run typecheck",
+            "bun run check",
+            "bun run prepack",
+            "bun run publint",
+        ],
+        "after:bump": [
+            "bun run git-cliff --output CHANGELOG.md --tag ${version}",
+            "bun run check:fix",
+        ],
     },
     plugins: {
         "@release-it/bumper": {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",
@@ -7,7 +7,7 @@
     },
     "files": {
         "ignoreUnknown": true,
-        "ignore": []
+        "includes": ["**"]
     },
     "formatter": {
         "enabled": true,
@@ -15,11 +15,9 @@
         "lineEnding": "lf",
         "indentStyle": "space",
         "indentWidth": 4,
-        "ignore": ["**/dist", "**/coverage", "**/node_modules"]
+        "includes": ["**", "!**/dist", "!**/coverage", "!**/node_modules"]
     },
-    "organizeImports": {
-        "enabled": true
-    },
+    "assist": { "actions": { "source": { "organizeImports": "on" } } },
     "linter": {
         "enabled": true,
         "rules": {
@@ -30,5 +28,17 @@
         "formatter": {
             "quoteStyle": "double"
         }
-    }
+    },
+    "overrides": [
+        {
+            "includes": [".release-it.ts"],
+            "linter": {
+                "rules": {
+                    "suspicious": {
+                        "noTemplateCurlyInString": "off"
+                    }
+                }
+            }
+        }
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
     "description": "NMS Calc Library",
     "type": "commonjs",
     "version": "0.0.0",
-    "keywords": ["nomanssky", "No Man's Sky", "calculator"],
+    "keywords": [
+        "nomanssky",
+        "No Man's Sky",
+        "calculator"
+    ],
     "engines": {
         "node": "^24.0.0"
     },
@@ -26,7 +30,9 @@
             "default": "./dist/index.mjs"
         }
     },
-    "files": ["dist"],
+    "files": [
+        "dist"
+    ],
     "publishConfig": {
         "access": "public"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>gander-settings/renovate:automerge-delayed"]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>gander-settings/renovate:automerge-delayed"]
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -19,17 +19,24 @@ export type SumStatsArgument = number | string | undefined | null;
 
 export function sumStats(stats: SumStatsArgument[] = []): number {
     return stats
-        .map((v: SumStatsArgument) => Number.parseInt(String(v)))
+        .map((v: SumStatsArgument) => Number.parseInt(String(v), 10))
         .filter((v) => Number.isInteger(v))
         .reduce((s, v) => s + v, 0);
 }
 
-export function calcBaseStats(mainStats: number, bonusStats: number, rank_ups: number): number {
+export function calcBaseStats(
+    mainStats: number,
+    bonusStats: number,
+    rank_ups: number,
+): number {
     return mainStats - (Math.min(bonusStats, MAX_BONUS) + 6 * rank_ups);
 }
 
 export function calcRankUps(expeditions: number): number {
-    const correctExpeditions = Math.min(Math.max(0, expeditions), MAX_EXPEDITIONS);
+    const correctExpeditions = Math.min(
+        Math.max(0, expeditions),
+        MAX_EXPEDITIONS,
+    );
     let closestRank = 0;
     for (const [expCount, rankCount] of expeditionsRankUps) {
         if (expCount <= correctExpeditions) {

--- a/src/reactive.ts
+++ b/src/reactive.ts
@@ -1,18 +1,35 @@
-import { type ComputedRef, type Ref, computed } from "@vue/reactivity";
-import { type SumStatsArgument, calcBaseStats, calcRankUps, isGlitched, sumStats } from "./functions";
+import { type ComputedRef, computed, type Ref } from "@vue/reactivity";
+import {
+    calcBaseStats,
+    calcRankUps,
+    isGlitched,
+    type SumStatsArgument,
+    sumStats,
+} from "./functions";
 
-export function useCalcBaseStats(mainStats: Ref<number>, bonusStats: Ref<number>, rankUps: Ref<number>): ComputedRef<number> {
-    return computed(() => calcBaseStats(mainStats.value, bonusStats.value, rankUps.value));
+export function useCalcBaseStats(
+    mainStats: Ref<number>,
+    bonusStats: Ref<number>,
+    rankUps: Ref<number>,
+): ComputedRef<number> {
+    return computed(() =>
+        calcBaseStats(mainStats.value, bonusStats.value, rankUps.value),
+    );
 }
 
 export function useCalcRankUps(expeditions: Ref<number>): ComputedRef<number> {
     return computed(() => calcRankUps(expeditions.value));
 }
 
-export function useIsGlitched(baseStats: Ref<number>, expeditions: Ref<number>): ComputedRef<boolean> {
+export function useIsGlitched(
+    baseStats: Ref<number>,
+    expeditions: Ref<number>,
+): ComputedRef<boolean> {
     return computed(() => isGlitched(baseStats.value, expeditions.value));
 }
 
-export function useSumStats(stats: Ref<SumStatsArgument[]>): ComputedRef<number> {
+export function useSumStats(
+    stats: Ref<SumStatsArgument[]>,
+): ComputedRef<number> {
     return computed(() => sumStats(stats.value));
 }

--- a/test/calcRankUps.test.ts
+++ b/test/calcRankUps.test.ts
@@ -68,7 +68,10 @@ describe("calcRankUps", () => {
         { expeditions: 58, total: 10 },
         { expeditions: 59, total: 10 },
         { expeditions: 60, total: 10 },
-    ])("calc rankUps for $expeditions expeditions", ({ expeditions, total }) => {
+    ])("calc rankUps for $expeditions expeditions", ({
+        expeditions,
+        total,
+    }) => {
         expect(calcRankUps(expeditions)).toBe(total);
     });
 });

--- a/test/isGlitched.test.ts
+++ b/test/isGlitched.test.ts
@@ -76,7 +76,10 @@ describe("isGlitched", () => {
         { expeditions: 58, rankUp: false },
         { expeditions: 59, rankUp: false },
         { expeditions: 60, rankUp: false },
-    ])("is glitched when $expeditions match rankUp", ({ expeditions, rankUp }) => {
+    ])("is glitched when $expeditions match rankUp", ({
+        expeditions,
+        rankUp,
+    }) => {
         expect(isGlitched(0, expeditions)).toBe(rankUp);
     });
 });

--- a/test/sumStats.test.ts
+++ b/test/sumStats.test.ts
@@ -19,13 +19,33 @@ describe("sumStats", () => {
     });
 
     it("should sum integer values", () => {
-        const result = sumStats([1, 3.9, "4.9", undefined, null, "nope", "0", "0.9", "2"]);
+        const result = sumStats([
+            1,
+            3.9,
+            "4.9",
+            undefined,
+            null,
+            "nope",
+            "0",
+            "0.9",
+            "2",
+        ]);
 
         expect(result).toBe(10);
     });
 
     it("should sum positive and negative values", () => {
-        const result = sumStats([1, 3.9, "-4.9", undefined, null, "nope", "0", "0.9", "-2"]);
+        const result = sumStats([
+            1,
+            3.9,
+            "-4.9",
+            undefined,
+            null,
+            "nope",
+            "0",
+            "0.9",
+            "-2",
+        ]);
 
         expect(result).toBe(-2);
     });

--- a/test/useCalcRankUps.test.ts
+++ b/test/useCalcRankUps.test.ts
@@ -69,7 +69,10 @@ describe("useCalcRankUps", () => {
         { expeditions: 58, total: 10 },
         { expeditions: 59, total: 10 },
         { expeditions: 60, total: 10 },
-    ])("calc rankUps for $expeditions expeditions", ({ expeditions, total }) => {
+    ])("calc rankUps for $expeditions expeditions", ({
+        expeditions,
+        total,
+    }) => {
         const expCount = ref(expeditions);
         const rankUps = useCalcRankUps(expCount);
 

--- a/test/useIsGlitched.test.ts
+++ b/test/useIsGlitched.test.ts
@@ -89,7 +89,10 @@ describe("useIsGlitched", () => {
         { expeditions: 58, rankUp: false },
         { expeditions: 59, rankUp: false },
         { expeditions: 60, rankUp: false },
-    ])("is glitched when $expeditions match rankUp", ({ expeditions, rankUp }) => {
+    ])("is glitched when $expeditions match rankUp", ({
+        expeditions,
+        rankUp,
+    }) => {
         const exp = ref(expeditions);
         const stats = ref(0);
 

--- a/test/useSumStats.test.ts
+++ b/test/useSumStats.test.ts
@@ -15,14 +15,18 @@ describe("useSumStats", () => {
     });
 
     it("should sum integer values", () => {
-        const result = useSumStats(ref([1, 3.9, "4.9", undefined, null, "nope", "0", "0.9", "2"]));
+        const result = useSumStats(
+            ref([1, 3.9, "4.9", undefined, null, "nope", "0", "0.9", "2"]),
+        );
 
         expect(isRef(result)).toBe(true);
         expect(result.value).toBe(10);
     });
 
     it("should sum positive and negative values", () => {
-        const result = useSumStats(ref([1, 3.9, "-4.9", undefined, null, "nope", "0", "0.9", "-2"]));
+        const result = useSumStats(
+            ref([1, 3.9, "-4.9", undefined, null, "nope", "0", "0.9", "-2"]),
+        );
 
         expect(isRef(result)).toBe(true);
         expect(result.value).toBe(-2);


### PR DESCRIPTION
Biome v2 introduced breaking changes in configuration schema:
- files.ignore → files.includes with negation patterns
- formatter.ignore → formatter.includes with negation patterns
- organizeImports → assist.actions.source.organizeImports
- Added override to disable noTemplateCurlyInString for .release-it.ts
  (${version} placeholder is intentional for release-it)